### PR TITLE
Add working Calva instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,17 @@ To make everyone's lives simpler, it is _recommended_ that use use VS Code with 
 
 To run the application using Calva:
 
-**FIXME: Does not work yet (need to start the server from the repl; cljs fails to connect)**
-
 * _View - Command Palette... - [Calva: Start a Project REPL and Connect (aka Jack-In)](https://calva.io/connect/)_
-* Select _deps.edn + shadow.clj_
-* Select `:dev` for the aliases to launch with
-* In the `output.calva-repl` window, type and execute `((requiring-resolve 'fulcro-todomvc.server/http-server))`
-* Select `:todomvc` for the build to connect to
+* Select shadow-cljs_
+* Select `:todomvc` for the aliases to launch with (Note it is not enough press `enter` on the item, you need to first press `space` or click the checkbox.)
+* Wait a few seconds, then select `:todomvc` for the build to connect to
+* Once you see the message `[:todomvc] Build completed.` in the Calva Jack-in terminal:
+    1. Open the file `src/fulcro_todomvc/server.clj`
+    1. Load the file: **Calva: Load current Current File and Dependencies**
+    1. Scroll down to the `(comment ...)` form and place the cursor in `(http-server)`, then press `alt+enter`
+       * This will evaluate the form (call the `http-server` function)
+       * The web browser will open with your application
+
 
 ### Running the app from the terminal
 


### PR DESCRIPTION
I've edited the instruction for how to start the app and its REPL using Calva.

I will make this clearer in Calva docs, but FYI:

* When you configure shadow-cljs to use `clojure/deps`, the correct Project type is `shadow-cljs`
* `deps + shadow-cljs` is for projects where shadow is not using `deps` for dependencies.

To add insult to injury there is a Calva bug that makes it hard to get a clean Clojure REPL once the ClojureScript REPL has started, in order to use the current instructions to start the server. I know how to do it, but the instructions are tricky to follow, so I changed those instructions to something that is more fail safe.