### PR TITLE
Sort TO DO items by label 

### DIFF
--- a/src/fulcro_todomvc/server.clj
+++ b/src/fulcro_todomvc/server.clj
@@ -120,7 +120,7 @@
   ;; outputs. For demo, we just always return the same list details.
   (case id
     1 {:list/title "The List"
-       :list/items (into [] (sort-by :item/id (vals @item-db)))}
+       :list/items (into [] (sort-by :item/label (vals @item-db)))}
     2 {:list/title "Another List"
        :list/items [{:item/id 99, :item/label "Hardcoded item", :item/complete true}
                     (assoc (get @item-db 1)


### PR DESCRIPTION
Currently the items in the to do list are sorted by id. Since the UUIDs are generated every time the application is loaded, the items are displayed in a different order every time. Sorting by label provides a consistent user experience.